### PR TITLE
Add Postgres dynamic env var generation

### DIFF
--- a/.travis.d/config.yaml
+++ b/.travis.d/config.yaml
@@ -6,3 +6,6 @@ cluster:
 
 mongo:
   host: 'altered-pug-mongodb'
+
+postgres:
+  host: 'postgres-postgresql'

--- a/.travis.d/config.yaml
+++ b/.travis.d/config.yaml
@@ -9,3 +9,5 @@ mongo:
 
 postgres:
   host: 'postgres-postgresql'
+  admin_user: 'postgres'
+  admin_password: 'qlLiDLk5L6'

--- a/.travis.d/config.yaml
+++ b/.travis.d/config.yaml
@@ -10,4 +10,3 @@ mongo:
 postgres:
   host: 'postgres-postgresql'
   admin_user: 'postgres'
-  admin_password: 'qlLiDLk5L6'

--- a/.travis.d/gen.rb
+++ b/.travis.d/gen.rb
@@ -312,6 +312,7 @@ biodomes = load_config
 # Create all the app's service and deployment conf files.
 biodomes.each do |dome_name, biodome|
   biodome['mongo'] = CONFIG['mongo']['host']
+  biodome['postgres'] = CONFIG['postgres']
 
   biodome['apps'].each do |app_name, app|
     app['files'].each do |mount, volume|

--- a/.travis.d/templates/deployment.yaml.erb
+++ b/.travis.d/templates/deployment.yaml.erb
@@ -38,6 +38,10 @@ spec:
               - name: MONGO_URL
                 value: !!str mongodb://<%= biodome['mongo'] %>/<%= app['uid'] %>
               <% end %>
+              <% if app['wants'] && app['wants']['postgres'] %>
+              - name: PG_URL
+                value: !!str postgres://<%= app['uid'] %>@<%= biodome['postgres']['host'] %>/<%= app['uid'] %>?sslmode=disable
+              <% end %>
               <% app['env']&.each do |name, value| %>
               - name: <%= name %>
               <% if value.is_a? Hash %>

--- a/.travis.d/templates/deployment.yaml.erb
+++ b/.travis.d/templates/deployment.yaml.erb
@@ -25,7 +25,7 @@ spec:
             name: "init-pg"
             env:
               - name: POSTGRES_URL
-                value: postgres://<%= biodome['postgres']['admin_user'] %>:<%= biodome['postgres']['admin_password'] %>@<%= biodome['postgres']['host'] %>/
+                value: postgres://<%= biodome['postgres']['admin_user'] %>@<%= biodome['postgres']['host'] %>/?sslmode=disable
               - name: USERNAME
                 value: app['uid']
               - name: DBNAME
@@ -48,11 +48,11 @@ spec:
                 value: <%= "https://#{app['host']}" %>
               <% if app['wants']%>
               <% if app['wants']['mongo'] %>
-              - name: <%= app['wants']['mongo'].is_a?(String) ? app['wants']['mongo'] : 'MONGO_URL' %>
+              - name: <%= app['wants']['mongo']['env'] ? app['wants']['mongo']['env'] : 'MONGO_URL' %>
                 value: !!str mongodb://<%= biodome['mongo'] %>/<%= app['uid'] %>
               <% end %>
               <% if app['wants']['postgres'] %>
-              - name: <%= app['wants']['postgres'].is_a?(String) ? app['wants']['postgres'] : 'POSTGRES_URL' %>
+              - name: <%= app['wants']['postgres']['env'] ? app['wants']['postgres']['env'] : 'POSTGRES_URL' %>
                 value: !!str postgres://<%= app['uid'] %>@<%= biodome['postgres']['host'] %>/<%= app['uid'] %>?sslmode=disable
               <% end %>
               <% end %>

--- a/.travis.d/templates/deployment.yaml.erb
+++ b/.travis.d/templates/deployment.yaml.erb
@@ -19,6 +19,18 @@ spec:
       labels:
         name: <%= app['uid'] %>
     spec:
+        initContainer:
+          <% if app['wants'] && app['wants']['postgres'] %>
+          - image: "hackgt/pg_initialaser:latest"
+            name: "init-pg"
+            env:
+              - name: POSTGRES_URL
+                value: postgres://<%= biodome['postgres']['admin_user'] %>:<%= biodome['postgres']['admin_password'] %>@<%= biodome['postgres']['host'] %>/
+              - name: USERNAME
+                value: app['uid']
+              - name: DBNAME
+                value: app['uid']
+          <% end %>
         containers:
           - image: <%= app['git']['user'] %>/<%= app['git']['shortname'] %>:<%= app['docker-tag'] %>
             imagePullPolicy: Always
@@ -34,13 +46,15 @@ spec:
                 value: !!str <%= app['target_port'] or 3000 %>
               - name: ROOT_URL
                 value: <%= "https://#{app['host']}" %>
-              <% if app['wants'] && app['wants']['mongo'] %>
+              <% if app['wants']%>
+              <% if app['wants']['mongo'] %>
               - name: MONGO_URL
                 value: !!str mongodb://<%= biodome['mongo'] %>/<%= app['uid'] %>
               <% end %>
-              <% if app['wants'] && app['wants']['postgres'] %>
-              - name: PG_URL
+              <% if app['wants']['postgres'] %>
+              - name: <%= app['wants']['postgres'].is_a?(String) ? app['wants']['postgres'] : 'POSTGRES_URL' %>
                 value: !!str postgres://<%= app['uid'] %>@<%= biodome['postgres']['host'] %>/<%= app['uid'] %>?sslmode=disable
+              <% end %>
               <% end %>
               <% app['env']&.each do |name, value| %>
               - name: <%= name %>
@@ -114,4 +128,3 @@ spec:
             <% end %>
           <% end %>
         <% end %>
-

--- a/.travis.d/templates/deployment.yaml.erb
+++ b/.travis.d/templates/deployment.yaml.erb
@@ -48,7 +48,7 @@ spec:
                 value: <%= "https://#{app['host']}" %>
               <% if app['wants']%>
               <% if app['wants']['mongo'] %>
-              - name: MONGO_URL
+              - name: <%= app['wants']['mongo'].is_a?(String) ? app['wants']['mongo'] : 'MONGO_URL' %>
                 value: !!str mongodb://<%= biodome['mongo'] %>/<%= app['uid'] %>
               <% end %>
               <% if app['wants']['postgres'] %>

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ target_port: 3000
 # (optional) defaults to port 80 if nothing is given.
 port: 80
 
-# a list of dependent services, currently only supports `mongo`
+# a list of dependent services, currently supports `mongo` and `postgres`
 # this is optional
 wants:
-    mongo: true
+    mongo: "CUSTOM_ENVVAR" # any string or boolean true
+    postgres: true         # if `true`, defaults to `POSTGRES_URL`
 
 # a list of secrets to be given through environment variables.
 # (optional) more on this in the secrets section...

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git:
     remote: https://github.com/HackGT/phonehome.git
     branch: master # optional
     rev: faceb00c  # optional, takes precedence over branch
-    
+
 # port the service will bind to, will be exposed through the `PORT` env var
 # if none is given a port will be decided for you
 target_port: 3000
@@ -54,8 +54,9 @@ port: 80
 # a list of dependent services, currently supports `mongo` and `postgres`
 # this is optional
 wants:
-    mongo: "CUSTOM_ENVVAR" # any string or boolean true
-    postgres: true         # if `true`, defaults to `POSTGRES_URL`
+    mongo:
+        env: CUSTOM_ENV_VAR
+    postgres: true # the env var will default to `POSTGRES_URL`
 
 # a list of secrets to be given through environment variables.
 # (optional) more on this in the secrets section...


### PR DESCRIPTION
**Goal of this PR:** enable containers to add `postgres: true` to their `want` stanza in `deployment.yaml` to dynamically insert `POSTGRES_URL` environment variable into the container with a connection url unique to each deployment (ex. production always points to the same database, PR deployments each point to their own database).

- [x] Implement connection url insertion
- [x] Option to specify the name of the environment variable that is added

Example: In `deployment.yaml` for an application were `app['uid'] = "portal-production"`,
```yaml
...
want:
    postgres: true
...
```
or
```yaml
...
want:
    postgres:
        env: POSTGRES_URL # this is the default value, specify any valid env var name as a string
...
```
Will result in the addition of  `POSTGRES_URL="postgres://portal-production@postgres-postgresql/portal-production?sslmode=disable"` in the container's environment. (`postgres-postgresql` is the PostgreSQL host in the cluster).

**Note:** This scheme assumes that all postgres users will be created without passwords. This should be fine because the DB is in the cluster and not exposed publicly. We can add more logic with secrets for authentication if desired.

---

**Update:** The following section have been implemented with 72f3850 and [pg_initialaser](https://github.com/HackGT/pg_initialaser)!

~**This alone will not be enough**~ **This PR also spawned and depends on [pg_initialaser](https://github.com/HackGT/pg_initialaser).**
The environment variable logic will work but the corresponding `PG_URL` will be invalid because no such user and database exist on the postgres host. 

To create those in an automated way, we will also need:
 - Support for pre-deploy scripts ([Init Containers???](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/))
 - Script creates a user and a database named the value of `app['uid']`.
Example from command line as postgres admin user with permissions to create users and databases (These commands also have corresponding sql statements that can be executed in a script - `CREATE USER` and `CREATE DATABASE`):
```bash
export PG_HOST=postgres-postgresql
export PG_ADMINUSER=postgres # ??? not sure if this is correct, also authentication might be a problem
export USERNAME=<value of app['uid']>
export DBNAME=<value of app['uid']>
createuser --host=$PG_HOST --username=$PG_ADMINUSER --no-createdb --no-createrole --no-superuser $USERNAME
createdb --host=$PG_HOST --username=$PG_ADMINUSER --owner=$USERNAME $DBNAME
```

This can be implemented idempotent-ly and run every time a deploy happens but should happen strictly before the database is created. Concurrency can be problematic in this operation which is why this additional functionality would be nice.